### PR TITLE
A few small fixes

### DIFF
--- a/tor-bridge/reactive/bridge.py
+++ b/tor-bridge/reactive/bridge.py
@@ -27,3 +27,4 @@ def update_torrc():
            )
     remove_state('tor.configured')
     set_state('tor.start')
+    hookenv.status_set('active', 'tor bridge ready')

--- a/tor-hidden/reactive/hidden.py
+++ b/tor-hidden/reactive/hidden.py
@@ -12,7 +12,7 @@ def config_with_reverseproxy(reverseproxy):
     cfg = hookenv.config()
 
     for service in services:
-        service_dir = '/var/lib/tor/%s' % (service['service_name'])
+        service_dir = '/var/lib/tor/{}'.format(service['service_name'])
         if not os.path.isdir(service_dir):
             check_call(['install', '-d', service_dir, '-o', 'debian-tor', '-m', '700'])
 

--- a/tor-hidden/tests/10-hidden
+++ b/tor-hidden/tests/10-hidden
@@ -32,5 +32,5 @@ tor_unit = d.sentry['tor-hidden'][0]
 print("checking hidden service hostname...", end='')
 out, rc = tor_unit.run('cat /var/lib/tor/apache2/hostname')
 assert rc==0, "failed to cat hidden service hostname"
-assert out.endswith(".onion"), "unexpected hostname: %s" % (out)
+assert out.endswith(".onion"), "unexpected hostname: {}".format(out)
 print("OK")

--- a/tor-relay/reactive/relay.py
+++ b/tor-relay/reactive/relay.py
@@ -33,6 +33,7 @@ def update_torrc():
            )
     remove_state('tor.configured')
     set_state('tor.start')
+    hookenv.status_set('active', 'tor relay {} is ready'.format(relay_nickname()))
 
 
 def relay_nickname():

--- a/tor/reactive/tor.py
+++ b/tor/reactive/tor.py
@@ -19,7 +19,7 @@ def install():
     # Remove universe/multiverse from sources, to avoid the out-of-date tor
     # package.
     check_call(['sed', '-i.torinstall', '/universe/d;/multiverse/d;', '/etc/apt/sources.list'])
-    charms.apt.add_source('deb http://deb.torproject.org/torproject.org {} main'.format(get_series()),
+    charms.apt.add_source('deb https://deb.torproject.org/torproject.org {} main'.format(get_series()),
                           key='A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89')
 
     charms.apt.queue_install(['deb.torproject.org-keyring', 'tor'])
@@ -33,8 +33,6 @@ def restart_tor():
     else:
         host.service_start('tor')
     set_state('tor.started')
-
-    hookenv.status_set('active', 'tor service ready')
 
 
 @when('tor.stop')


### PR DESCRIPTION
- Install tor over HTTPS by default per upstream instructions:

https://2019.www.torproject.org/docs/debian.html.en#ubuntu

 - remove racey status_set from base tor layer, replace with a custom message per application layer

- Also convert %s substitutions to .format()-style